### PR TITLE
Address Pico W issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,17 @@ cmake_minimum_required(VERSION 3.24)
 
 # Set the board type for pin and LED decisions
 #set(PICO_BOARD pico)
-#set(PICO_BOARD pico_w)
-set(PICO_BOARD waveshare_rp2040_zero)
+set(PICO_BOARD pico_w)
+#set(PICO_BOARD waveshare_rp2040_zero)
 #set(PICO_BOARD seeed_xiao_rp2040)
 
 # GMT Offset for clock display (if used)
 # add_compile_definitions(GPSD_GMT_OFFSET=-5.0)
 
 # Enable to display VSYS voltage
-# add_compile_definitions(VOLTAGE_DISPLAY)
-
+if ((PICO_BOARD STREQUAL pico) OR (PICO_BOARD STREQUAL pico_w))
+  add_compile_definitions(VOLTAGE_DISPLAY)
+endif()
 
 # initialize the SDK based on PICO_SDK_PATH
 # note: this must happen before project()

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -47,7 +47,7 @@ static std::map<std::string, eSentenceType> g_SentenceTypeMap = {
     {"$GPRMC", kGPRMC},
     {"$GPVTG", kGPVTG},
     {"$PGTOP", kPGTOP},
-    {"$PCDP",  kPCD  },
+    {"$PCD",   kPCD  },
 };
 
 static GPS* sg_pGPS          = NULL;
@@ -91,10 +91,6 @@ void GPS::SetGpsDataCallback(void* pCtx, gpsDataCallback pCB)
 
 void GPS::Run()
 {
-#if !defined(NDEBUG)
-    sleep_ms(10000);
-#endif
-
     // Set up GPS
     uart_set_fifo_enabled(m_pUART0, true);
     sg_pGPS     = this; // Allow interrupt handler to call us back
@@ -129,8 +125,8 @@ void GPS::Run()
                 // until some data is received to ensure the GPS has finished initializing.
                 std::string strPGCMD("$PGCMD,33,1*6C\r\n"); // Enable antenna output for PA6H
                 std::string strCDCMD("$CDCMD,33,1*7C\r\n"); // Enable antenna output for PA1616S
-                uart_write_blocking(m_pUART0, (const uint8_t*)strPGCMD.c_str(), strPGCMD.length());
-                uart_write_blocking(m_pUART0, (const uint8_t*)strCDCMD.c_str(), strCDCMD.length());
+                uart_puts(m_pUART0, strPGCMD.c_str());
+                uart_puts(m_pUART0, strCDCMD.c_str());
                 bSentAntennaCommands = true;
             }
         }

--- a/src/gps_oled.cpp
+++ b/src/gps_oled.cpp
@@ -144,6 +144,7 @@ void GPS_OLED::updateUI(GPSData::Shared spGPSData)
 
     // Draw fix and #sats text
     drawText(0, spGPSData->strMode3D, COLOUR_WHITE, false, X_PAD);
+    drawText(-1, m_spGPSData->bExternalAntenna ? "*" : " ", COLOUR_WHITE, false, X_PAD);
     drawText(3, spGPSData->strNumSats, COLOUR_WHITE, true, X_PAD);
 
     if (!spGPSData->strGPSTime.empty())

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -135,9 +135,11 @@ void LED_neo::SetPixel(uint idx, uint32_t color)
     m_vPixels[idx] = color;
 }
 
+
 #if defined(RASPBERRYPI_PICO_W)
 LED_pico_w::LED_pico_w(uint pin)
-    : LED_pico(pin)
+    : m_nPin(pin),
+      m_nColor(led_white)
 {
     Off();
 }
@@ -162,5 +164,15 @@ void LED_pico_w::On()
 void LED_pico_w::Off()
 {
     cyw43_arch_gpio_put(m_nPin, 0);
+}
+
+void LED_pico_w::SetPixel(uint idx, uint32_t color)
+{
+    m_nColor = color;
+}
+
+void LED_pico_w::SetIgnore(std::vector<uint32_t> vIgnore)
+{
+    m_vIgnore = vIgnore;
 }
 #endif

--- a/src/led.h
+++ b/src/led.h
@@ -98,13 +98,21 @@ private:
 };
 
 #if defined(RASPBERRYPI_PICO_W)
-class LED_pico_w : public LED_pico
+class LED_pico_w : public LED
 {
 public:
     LED_pico_w(uint pin);
     virtual ~LED_pico_w();
 
-    void On();
-    void Off();
+    void Initialize() override {};
+    void On() override;
+    void Off() override;
+    void SetPixel(uint idx, uint32_t color) override;
+    void SetIgnore(std::vector<uint32_t> vIgnore) override;
+
+protected:
+    uint m_nPin;
+    uint32_t m_nColor;
+    std::vector<uint32_t> m_vIgnore;
 };
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,10 @@ int main()
     stdio_init_all();
     adc_init();
 
+#if !defined(NDEBUG)
+    sleep_ms(10000);
+#endif
+
     // Set up UART for GPS device
     uart_init(UART0_DEVICE, UART_BAUD_RATE);
     gpio_set_function(PIN_UART0_TX, GPIO_FUNC_UART);
@@ -114,13 +118,13 @@ int main()
     spLED->SetPixel(0, led_green);
 #elif defined(USE_LED_PIN)
     spLED = std::make_shared<LED_pico>(USE_LED_PIN);
-    spLED->SetIgnore({led_red});
+    spLED->SetIgnore({led_red, led_magenta});
 #elif defined(PICO_DEFAULT_LED_PIN)
     spLED = std::make_shared<LED_pico>(PICO_DEFAULT_LED_PIN);
-    spLED->SetIgnore({led_red});
+    spLED->SetIgnore({led_red, led_magenta});
 #elif defined(RASPBERRYPI_PICO_W)
     spLED = std::make_shared<LED_pico_w>(CYW43_WL_GPIO_LED_PIN);
-    spLED->SetIgnore({led_red});
+    spLED->SetIgnore({led_red, led_magenta});
 #endif
 
 // Create the GPS object


### PR DESCRIPTION
Commands to enable external antenna detection to Adafruit GPS were not being sent on UART0 GPIO 0, but only on Pico W devices.  Turns out the LED class for Pico W was inheriting from the one for Pico, which was initializing the GPIO for its LED.  However, the CYW43 chipset that manages the LED on the Pico W numbers its virtual GPIO as 0, so the parent class was overriding the real GPIO 0.